### PR TITLE
Unbreak examples in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,9 +24,9 @@ Basic usage instructions
 
 3. Hash a password using a salt with the default number of rounds::
 
-        1> {ok, Salt} = bcrypt:gen_salt(),
+        1> {ok, Salt} = bcrypt:gen_salt().
         {ok,"$2a$12$sSS8Eg.ovVzaHzi1nUHYK."}
-        2> {ok, Hash} = bcrypt:hashpw("foo", Salt),
+        2> {ok, Hash} = bcrypt:hashpw("foo", Salt).
         {ok,"$2a$12$sSS8Eg.ovVzaHzi1nUHYK.HbUIOdlQI0iS22Q5rd5z.JVVYH6sfm6"}
 
 3. Verify the password::


### PR DESCRIPTION
Two examples in the README are not valid erlang code; this commit fixes that.
