### PR TITLE
Convert to envy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ logs/*
 
 ## Temporary script for compiling the port
 build_port.sh
+
+## Deps
+deps

--- a/rebar.config
+++ b/rebar.config
@@ -14,3 +14,8 @@
 {post_hooks,
  [{clean, "make -C c_src clean"},
   {compile, "make -C c_src"}]}.
+
+{deps, [
+         {envy, ".*",
+         {git, "git://github.com/manderson26/envy.git", {branch, "master"}}}
+      ]}.

--- a/src/bcrypt.erl
+++ b/src/bcrypt.erl
@@ -12,9 +12,8 @@ start() -> application:start(bcrypt).
 stop()  -> application:stop(bcrypt).
 
 mechanism() ->
-    {ok, M} = application:get_env(bcrypt, mechanism),
-    M.
-
+    envy:get(bcrypt, mechanism, atom).
+   
 gen_salt() -> do_gen_salt(mechanism()).
 gen_salt(Rounds) -> do_gen_salt(mechanism(), Rounds).
 hashpw(Password, Salt) -> do_hashpw(mechanism(), Password, Salt).

--- a/src/bcrypt_nif_worker.erl
+++ b/src/bcrypt_nif_worker.erl
@@ -27,7 +27,7 @@ hashpw(Password, Salt) ->
     gen_server:call(?MODULE, {hashpw, Password, Salt}, infinity).
 
 init([]) ->
-    {ok, Default} = application:get_env(bcrypt, default_log_rounds),
+    Default = envy:get(bcrypt, default_log_rounds, non_neg_integer),
     Ctx = bcrypt_nif:create_ctx(),
     {ok, #state{default_log_rounds = Default, context = Ctx}}.
 

--- a/src/bcrypt_pool.erl
+++ b/src/bcrypt_pool.erl
@@ -30,7 +30,7 @@ gen_salt(Rounds)       -> do_call(fun bcrypt_port:gen_salt/2, [Rounds]).
 hashpw(Password, Salt) -> do_call(fun bcrypt_port:hashpw/3, [Password, Salt]).
 
 init([]) ->
-    {ok, Size} = application:get_env(bcrypt, pool_size),
+    Size = envy:get(bcrypt, pool_size, non_neg_integer),
     {ok, #state{size = Size}}.
 
 terminate(shutdown, _) -> ok.

--- a/src/bcrypt_port.erl
+++ b/src/bcrypt_port.erl
@@ -58,7 +58,7 @@ init([Filename]) ->
             Port = open_port(
                      {spawn, Filename}, [{packet, 2}, binary, exit_status]),
             ok = bcrypt_pool:available(self()),
-            {ok, Rounds} = application:get_env(bcrypt, default_log_rounds),
+            Rounds = envy:get(bcrypt, default_log_rounds, non_neg_integer),
             {ok, #state{port = Port, default_log_rounds = Rounds}};
         {error, Reason} ->
             ?BCRYPT_ERROR("Can't open file ~p: ~p", [Filename, Reason]),

--- a/src/bcrypt_sup.erl
+++ b/src/bcrypt_sup.erl
@@ -18,8 +18,7 @@ init([]) ->
     NifChildren
         = [{bcrypt_nif_worker, {bcrypt_nif_worker, start_link, []}, permanent,
             16#ffffffff, worker, [bcrypt_nif_worker]}],
-    case application:get_env(bcrypt, mechanism) of
-        undefined  -> {stop, no_mechanism_defined};
-        {ok, nif}  -> {ok, {{one_for_all, 1, 1}, NifChildren}};
-        {ok, port} -> {ok, {{one_for_all, 15, 60}, PortChildren}}
+    case envy:get(bcrypt, mechanism, atom)  of
+        nif  -> {ok, {{one_for_all, 1, 1}, NifChildren}};
+        port -> {ok, {{one_for_all, 15, 60}, PortChildren}}
     end.


### PR DESCRIPTION
Application:get_env requires validation of data types.  This logic has been 
duplicated several times.  This attempts to consolidate validation to a single
library, envy.
