### PR TITLE
solaris compatibility

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,6 +7,7 @@
 {port_env,
  [{"DRV_LDFLAGS","-shared $ERL_LDFLAGS -lpthread"},
   {"darwin", "DRV_LDFLAGS", "-bundle -flat_namespace -undefined suppress $ERL_LDFLAGS -lpthread"},
+  {"solaris", "ERL_CFLAGS", "-lnsl $ERL_CFLAGS"},
   {"DRV_CFLAGS","-Ic_src -Wall -fPIC $ERL_CFLAGS"}]}.
 
 {port_specs, [{"priv/bcrypt_nif.so", ["c_src/*.c"]}]}.


### PR DESCRIPTION
This patch adds the required compiler flags to compile erlang-bcrypt under SmartOS.
