### PR TITLE
Change compilation method to support Rebar 3

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -1,9 +1,78 @@
-compile: ../priv/bcrypt
+# Based on c_src.mk from erlang.mk by Loic Hoguin <essen@ninenines.eu>
 
-../priv/bcrypt:
-	$(CC) $(CFLAGS) $(ERL_CFLAGS) $(EXE_LDFLAGS) bcrypt_port.c bcrypt.o blowfish.o $(LDFLAGS) $(ERL_LDFLAGS) -lpthread -o ../priv/bcrypt
+CURDIR := $(shell pwd)
+BASEDIR := $(abspath $(CURDIR)/..)
+
+PROJECT ?= $(notdir $(BASEDIR))
+PROJECT := $(strip $(PROJECT))
+
+ERTS_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s/erts-~s/include/\", [code:root_dir(), erlang:system_info(version)]).")
+ERL_INTERFACE_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s\", [code:lib_dir(erl_interface, include)]).")
+ERL_INTERFACE_LIB_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s\", [code:lib_dir(erl_interface, lib)]).")
+
+C_SRC_DIR = $(CURDIR)
+C_SRC_OUTPUT ?= $(CURDIR)/../priv/bcrypt_nif.so
+
+# System type and C compiler/flags.
+
+UNAME_SYS := $(shell uname -s)
+ifeq ($(UNAME_SYS), Darwin)
+	CC ?= cc
+	CFLAGS ?= -O3 -std=c99 -arch x86_64 -Wall
+	CXXFLAGS ?= -O3 -arch x86_64 -Wall
+	LDFLAGS ?= -arch x86_64 -flat_namespace -undefined suppress
+else ifeq ($(UNAME_SYS), FreeBSD)
+	CC ?= cc
+	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall
+	CXXFLAGS ?= -O3 -finline-functions -Wall
+else ifeq ($(UNAME_SYS), Linux)
+	CC ?= gcc
+	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall
+	CXXFLAGS ?= -O3 -finline-functions -Wall
+endif
+
+CFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR)
+CXXFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR)
+
+LDLIBS += -L $(ERL_INTERFACE_LIB_DIR) -lerl_interface -lei
+
+# Verbosity.
+
+c_verbose_0 = @echo " C     " $(?F);
+c_verbose = $(c_verbose_$(V))
+
+cpp_verbose_0 = @echo " CPP   " $(?F);
+cpp_verbose = $(cpp_verbose_$(V))
+
+link_verbose_0 = @echo " LD    " $(@F);
+link_verbose = $(link_verbose_$(V))
+
+SOURCES := $(shell find $(C_SRC_DIR) -type f \( -name "*.c" -o -name "*.C" -o -name "*.cc" -o -name "*.cpp" \))
+OBJECTS = $(addsuffix .o, $(basename $(SOURCES)))
+
+COMPILE_C = $(c_verbose) $(CC) $(CFLAGS) $(CPPFLAGS) -c
+COMPILE_CPP = $(cpp_verbose) $(CXX) $(CXXFLAGS) $(CPPFLAGS) -c
+
+all: $(C_SRC_OUTPUT) ../priv/bcrypt
+
+../priv/bcrypt: $(OBJECTS)
+	$(CC) $(CFLAGS) bcrypt_port.c bcrypt.o blowfish.o $(LDFLAGS) ${LDLIBS} -lpthread -o ../priv/bcrypt
+
+$(C_SRC_OUTPUT): $(OBJECTS)
+	@mkdir -p $(BASEDIR)/priv/
+	$(link_verbose) $(CC) $(OBJECTS) $(LDFLAGS) $(LDLIBS) -shared -o $(C_SRC_OUTPUT)
+
+%.o: %.c
+	$(COMPILE_C) $(OUTPUT_OPTION) $<
+
+%.o: %.cc
+	$(COMPILE_CPP) $(OUTPUT_OPTION) $<
+
+%.o: %.C
+	$(COMPILE_CPP) $(OUTPUT_OPTION) $<
+
+%.o: %.cpp
+	$(COMPILE_CPP) $(OUTPUT_OPTION) $<
 
 clean:
-	@rm -f ../priv/bcrypt
-
-.PHONY: clean compile
+	@rm -f $(C_SRC_OUTPUT) $(OBJECTS) ../priv/bcrypt

--- a/c_src/erl_blf.h
+++ b/c_src/erl_blf.h
@@ -42,6 +42,8 @@
 #define u_int64_t uint64_t
 #endif
 
+#include <sys/types.h>
+
 /* Schneier specifies a maximum key length of 56 bytes.
  * This ensures that every key bit affects every cipher
  * bit.  However, the subkeys can hold up to 72 bytes.

--- a/rebar.config
+++ b/rebar.config
@@ -1,17 +1,5 @@
 %% -*- mode: erlang;erlang-indent-level: 2;indent-tabs-mode: nil -*-
 %% {erl_opts, [debug_info]}.
 
-%% {so_specs,
-%%  [{"priv/bcrypt_nif.so",
-%%    ["c_src/*.c"]}]}.
-{port_env,
- [{"DRV_LDFLAGS","-shared $ERL_LDFLAGS -lpthread"},
-  {"darwin", "DRV_LDFLAGS", "-bundle -flat_namespace -undefined suppress $ERL_LDFLAGS -lpthread"},
-  {"solaris", "ERL_CFLAGS", "-lnsl $ERL_CFLAGS"},
-  {"DRV_CFLAGS","-Ic_src -Wall -fPIC $ERL_CFLAGS"}]}.
-
-{port_specs, [{"priv/bcrypt_nif.so", ["c_src/*.c"]}]}.
-
-{post_hooks,
- [{clean, "make -C c_src clean"},
-  {compile, "make -C c_src"}]}.
+{pre_hooks, [{"(linux|darwin|solaris)", compile, "make -C c_src"}]}.
+{post_hooks, [{"(linux|darwin|solaris)", clean, "make -C c_src clean"}]}.


### PR DESCRIPTION
In rebar 3, the built-in method of building NIFs has been removed, and they now recommend you use a Makefile instead. I've replaced the rebar NIF build magic with rebar 3's standard Makefile.

I've tested this builds successfully and the unit test suite passes using rebar 2 and 3 on Ubuntu 14.04 and OS X.
