### PR TITLE
fix targets in c_src/Makefile

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -1,7 +1,7 @@
 compile: ../priv/bcrypt
 
 ../priv/bcrypt:
-	$(CC) $(CFLAGS) $(ERL_CFLAGS) $(EXE_LDFLAGS) bcrypt_port.c bcrypt.o blowfish.o $(LDFLAGS) $(ERL_LDFLAGS) -lpthread -o ../priv/bcrypt
+	$(CC) $(CFLAGS) $(ERL_CFLAGS) $(EXE_LDFLAGS) bcrypt_port.c bcrypt.c blowfish.c $(LDFLAGS) $(ERL_LDFLAGS) -lpthread -o ../priv/bcrypt
 
 clean:
 	@rm -f ../priv/bcrypt


### PR DESCRIPTION
C-compiler compiles *.c files, not *.o

Current version doesn't work with erlang.mk projects.
