### PR TITLE
Include sys/types.h for u_int_*.

### DIFF
--- a/c_src/erl_blf.h
+++ b/c_src/erl_blf.h
@@ -34,6 +34,8 @@
 #ifndef _ERL_BLF_H_
 #define _ERL_BLF_H_
 
+#include <sys/types.h>
+
 /* Solaris compatibility */
 #ifdef __sun
 #define u_int8_t uint8_t


### PR DESCRIPTION
Not including the above header causes compilation failures on some platforms.
